### PR TITLE
Implementing  list user

### DIFF
--- a/dgh-platform/backend/api-gateway/apps/users/urls.py
+++ b/dgh-platform/backend/api-gateway/apps/users/urls.py
@@ -5,7 +5,8 @@ from .views import (
     RegisterPatientView,
     RegisterProfessionalView,
     login_view,
-    logout_view
+    logout_view,
+    list_patients
 )
 
 urlpatterns = [
@@ -14,4 +15,5 @@ urlpatterns = [
     path('login/', login_view, name='login'),
     path('logout/', logout_view, name='logout'),
     path('token/refresh/', TokenRefreshView.as_view(), name='token-refresh'),
+    path('patients/', list_patients, name='list-patients'),
 ]


### PR DESCRIPTION
Added the feature of listing partients on the professional part

## Summary by Sourcery

Implement an authenticated API endpoint to list patients with Swagger documentation, response ordering, and logging

New Features:
- Add authenticated GET /patients endpoint to retrieve all patients with count and detailed fields

Enhancements:
- Annotate the endpoint with Swagger/OpenAPI documentation
- Order patients by creation timestamp and include request/error logging