### PR TITLE
retry forecasting

### DIFF
--- a/dgh-platform/bloodbank/frontend/components/forecasting.tsx
+++ b/dgh-platform/bloodbank/frontend/components/forecasting.tsx
@@ -37,7 +37,7 @@ import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContai
 
 // Configuration API
 const API_CONFIG = {
-  baseUrl: process.env.REACT_APP_API_URL || 'http://localhost:8000/api/v1',
+  baseUrl: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1',
   timeout: 10000,
   retryAttempts: 3,
   retryDelay: 1000


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Replace REACT_APP_API_URL with NEXT_PUBLIC_API_URL for the forecasting API base URL